### PR TITLE
네트워크 통신(HTTP) 구현

### DIFF
--- a/BithumbYagomAcamedy.xcodeproj/project.pbxproj
+++ b/BithumbYagomAcamedy.xcodeproj/project.pbxproj
@@ -10,6 +10,8 @@
 		08AF803127C742AB00790762 /* APIProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08AF803027C742AB00790762 /* APIProtocol.swift */; };
 		08AF803427C7452300790762 /* URLRequest+extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08AF803327C7452300790762 /* URLRequest+extension.swift */; };
 		08AF803627C755A600790762 /* URLSession+extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08AF803527C755A600790762 /* URLSession+extension.swift */; };
+		08AF803827C7569D00790762 /* NetworkServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08AF803727C7569D00790762 /* NetworkServiceTests.swift */; };
+		08AF803C27C756E500790762 /* MockURLSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08AF803B27C756E500790762 /* MockURLSession.swift */; };
 		08F5EA4727C626350031EF4C /* CoinList.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 08F5EA4627C626350031EF4C /* CoinList.storyboard */; };
 		08F5EA4A27C626E60031EF4C /* MoreDetail.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 08F5EA4927C626E60031EF4C /* MoreDetail.storyboard */; };
 		08F5EA4D27C627450031EF4C /* DepositWithdrawalStatus.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 08F5EA4C27C627450031EF4C /* DepositWithdrawalStatus.storyboard */; };
@@ -38,6 +40,8 @@
 		08AF803027C742AB00790762 /* APIProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIProtocol.swift; sourceTree = "<group>"; };
 		08AF803327C7452300790762 /* URLRequest+extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "URLRequest+extension.swift"; sourceTree = "<group>"; };
 		08AF803527C755A600790762 /* URLSession+extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "URLSession+extension.swift"; sourceTree = "<group>"; };
+		08AF803727C7569D00790762 /* NetworkServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkServiceTests.swift; sourceTree = "<group>"; };
+		08AF803B27C756E500790762 /* MockURLSession.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockURLSession.swift; sourceTree = "<group>"; };
 		08F5EA4627C626350031EF4C /* CoinList.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = CoinList.storyboard; sourceTree = "<group>"; };
 		08F5EA4927C626E60031EF4C /* MoreDetail.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = MoreDetail.storyboard; sourceTree = "<group>"; };
 		08F5EA4C27C627450031EF4C /* DepositWithdrawalStatus.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = DepositWithdrawalStatus.storyboard; sourceTree = "<group>"; };
@@ -88,6 +92,23 @@
 				08AF803527C755A600790762 /* URLSession+extension.swift */,
 			);
 			path = Extension;
+			sourceTree = "<group>";
+		};
+		08AF803927C756BD00790762 /* NetworkServiceTest */ = {
+			isa = PBXGroup;
+			children = (
+				08AF803A27C756D400790762 /* Mock */,
+				08AF803727C7569D00790762 /* NetworkServiceTests.swift */,
+			);
+			path = NetworkServiceTest;
+			sourceTree = "<group>";
+		};
+		08AF803A27C756D400790762 /* Mock */ = {
+			isa = PBXGroup;
+			children = (
+				08AF803B27C756E500790762 /* MockURLSession.swift */,
+			);
+			path = Mock;
 			sourceTree = "<group>";
 		};
 		08F5EA4127C622F60031EF4C /* Resource */ = {
@@ -196,6 +217,7 @@
 		37A15AE227C61D0D00585F4A /* BithumbYagomAcamedyTests */ = {
 			isa = PBXGroup;
 			children = (
+				08AF803927C756BD00790762 /* NetworkServiceTest */,
 				37A15AE327C61D0D00585F4A /* BithumbYagomAcamedyTests.swift */,
 			);
 			path = BithumbYagomAcamedyTests;
@@ -320,6 +342,8 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				08AF803C27C756E500790762 /* MockURLSession.swift in Sources */,
+				08AF803827C7569D00790762 /* NetworkServiceTests.swift in Sources */,
 				37A15AE427C61D0D00585F4A /* BithumbYagomAcamedyTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/BithumbYagomAcamedy.xcodeproj/project.pbxproj
+++ b/BithumbYagomAcamedy.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		08AF803127C742AB00790762 /* APIProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08AF803027C742AB00790762 /* APIProtocol.swift */; };
+		08AF803427C7452300790762 /* URLRequest+extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08AF803327C7452300790762 /* URLRequest+extension.swift */; };
 		08F5EA4727C626350031EF4C /* CoinList.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 08F5EA4627C626350031EF4C /* CoinList.storyboard */; };
 		08F5EA4A27C626E60031EF4C /* MoreDetail.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 08F5EA4927C626E60031EF4C /* MoreDetail.storyboard */; };
 		08F5EA4D27C627450031EF4C /* DepositWithdrawalStatus.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 08F5EA4C27C627450031EF4C /* DepositWithdrawalStatus.storyboard */; };
@@ -34,6 +35,7 @@
 
 /* Begin PBXFileReference section */
 		08AF803027C742AB00790762 /* APIProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIProtocol.swift; sourceTree = "<group>"; };
+		08AF803327C7452300790762 /* URLRequest+extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "URLRequest+extension.swift"; sourceTree = "<group>"; };
 		08F5EA4627C626350031EF4C /* CoinList.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = CoinList.storyboard; sourceTree = "<group>"; };
 		08F5EA4927C626E60031EF4C /* MoreDetail.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = MoreDetail.storyboard; sourceTree = "<group>"; };
 		08F5EA4C27C627450031EF4C /* DepositWithdrawalStatus.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = DepositWithdrawalStatus.storyboard; sourceTree = "<group>"; };
@@ -75,6 +77,14 @@
 				08AF803027C742AB00790762 /* APIProtocol.swift */,
 			);
 			path = Protocol;
+			sourceTree = "<group>";
+		};
+		08AF803227C744B200790762 /* Extension */ = {
+			isa = PBXGroup;
+			children = (
+				08AF803327C7452300790762 /* URLRequest+extension.swift */,
+			);
+			path = Extension;
 			sourceTree = "<group>";
 		};
 		08F5EA4127C622F60031EF4C /* Resource */ = {
@@ -169,6 +179,7 @@
 		37A15AC827C61D0A00585F4A /* BithumbYagomAcamedy */ = {
 			isa = PBXGroup;
 			children = (
+				08AF803227C744B200790762 /* Extension */,
 				08AF802F27C7429A00790762 /* Protocol */,
 				08F5EA4E27C688160031EF4C /* Utility */,
 				08F5EA4327C623EE0031EF4C /* AppLifeCycle */,
@@ -292,6 +303,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				08F5EA5027C689710031EF4C /* NetworkService.swift in Sources */,
+				08AF803427C7452300790762 /* URLRequest+extension.swift in Sources */,
 				37A15AD427C61D0A00585F4A /* BithumbYagomAcamedy.xcdatamodeld in Sources */,
 				37A15ACE27C61D0A00585F4A /* MainTabBarController.swift in Sources */,
 				37A15ACA27C61D0A00585F4A /* AppDelegate.swift in Sources */,

--- a/BithumbYagomAcamedy.xcodeproj/project.pbxproj
+++ b/BithumbYagomAcamedy.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		08AF803127C742AB00790762 /* APIProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08AF803027C742AB00790762 /* APIProtocol.swift */; };
 		08F5EA4727C626350031EF4C /* CoinList.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 08F5EA4627C626350031EF4C /* CoinList.storyboard */; };
 		08F5EA4A27C626E60031EF4C /* MoreDetail.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 08F5EA4927C626E60031EF4C /* MoreDetail.storyboard */; };
 		08F5EA4D27C627450031EF4C /* DepositWithdrawalStatus.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 08F5EA4C27C627450031EF4C /* DepositWithdrawalStatus.storyboard */; };
@@ -32,6 +33,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		08AF803027C742AB00790762 /* APIProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIProtocol.swift; sourceTree = "<group>"; };
 		08F5EA4627C626350031EF4C /* CoinList.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = CoinList.storyboard; sourceTree = "<group>"; };
 		08F5EA4927C626E60031EF4C /* MoreDetail.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = MoreDetail.storyboard; sourceTree = "<group>"; };
 		08F5EA4C27C627450031EF4C /* DepositWithdrawalStatus.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = DepositWithdrawalStatus.storyboard; sourceTree = "<group>"; };
@@ -67,6 +69,14 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		08AF802F27C7429A00790762 /* Protocol */ = {
+			isa = PBXGroup;
+			children = (
+				08AF803027C742AB00790762 /* APIProtocol.swift */,
+			);
+			path = Protocol;
+			sourceTree = "<group>";
+		};
 		08F5EA4127C622F60031EF4C /* Resource */ = {
 			isa = PBXGroup;
 			children = (
@@ -159,6 +169,7 @@
 		37A15AC827C61D0A00585F4A /* BithumbYagomAcamedy */ = {
 			isa = PBXGroup;
 			children = (
+				08AF802F27C7429A00790762 /* Protocol */,
 				08F5EA4E27C688160031EF4C /* Utility */,
 				08F5EA4327C623EE0031EF4C /* AppLifeCycle */,
 				08F5EA4127C622F60031EF4C /* Resource */,
@@ -284,6 +295,7 @@
 				37A15AD427C61D0A00585F4A /* BithumbYagomAcamedy.xcdatamodeld in Sources */,
 				37A15ACE27C61D0A00585F4A /* MainTabBarController.swift in Sources */,
 				37A15ACA27C61D0A00585F4A /* AppDelegate.swift in Sources */,
+				08AF803127C742AB00790762 /* APIProtocol.swift in Sources */,
 				37A15ACC27C61D0A00585F4A /* SceneDelegate.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/BithumbYagomAcamedy.xcodeproj/project.pbxproj
+++ b/BithumbYagomAcamedy.xcodeproj/project.pbxproj
@@ -7,7 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		08AF803127C742AB00790762 /* APIProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08AF803027C742AB00790762 /* APIProtocol.swift */; };
+		08AF803127C742AB00790762 /* APIable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08AF803027C742AB00790762 /* APIable.swift */; };
 		08AF803427C7452300790762 /* URLRequest+extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08AF803327C7452300790762 /* URLRequest+extension.swift */; };
 		08AF803627C755A600790762 /* URLSession+extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08AF803527C755A600790762 /* URLSession+extension.swift */; };
 		08AF803827C7569D00790762 /* NetworkServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08AF803727C7569D00790762 /* NetworkServiceTests.swift */; };
@@ -37,7 +37,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
-		08AF803027C742AB00790762 /* APIProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIProtocol.swift; sourceTree = "<group>"; };
+		08AF803027C742AB00790762 /* APIable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIable.swift; sourceTree = "<group>"; };
 		08AF803327C7452300790762 /* URLRequest+extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "URLRequest+extension.swift"; sourceTree = "<group>"; };
 		08AF803527C755A600790762 /* URLSession+extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "URLSession+extension.swift"; sourceTree = "<group>"; };
 		08AF803727C7569D00790762 /* NetworkServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkServiceTests.swift; sourceTree = "<group>"; };
@@ -80,7 +80,7 @@
 		08AF802F27C7429A00790762 /* Protocol */ = {
 			isa = PBXGroup;
 			children = (
-				08AF803027C742AB00790762 /* APIProtocol.swift */,
+				08AF803027C742AB00790762 /* APIable.swift */,
 			);
 			path = Protocol;
 			sourceTree = "<group>";
@@ -333,7 +333,7 @@
 				37A15ACE27C61D0A00585F4A /* MainTabBarController.swift in Sources */,
 				08AF803627C755A600790762 /* URLSession+extension.swift in Sources */,
 				37A15ACA27C61D0A00585F4A /* AppDelegate.swift in Sources */,
-				08AF803127C742AB00790762 /* APIProtocol.swift in Sources */,
+				08AF803127C742AB00790762 /* APIable.swift in Sources */,
 				37A15ACC27C61D0A00585F4A /* SceneDelegate.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/BithumbYagomAcamedy.xcodeproj/project.pbxproj
+++ b/BithumbYagomAcamedy.xcodeproj/project.pbxproj
@@ -9,6 +9,7 @@
 /* Begin PBXBuildFile section */
 		08AF803127C742AB00790762 /* APIProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08AF803027C742AB00790762 /* APIProtocol.swift */; };
 		08AF803427C7452300790762 /* URLRequest+extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08AF803327C7452300790762 /* URLRequest+extension.swift */; };
+		08AF803627C755A600790762 /* URLSession+extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08AF803527C755A600790762 /* URLSession+extension.swift */; };
 		08F5EA4727C626350031EF4C /* CoinList.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 08F5EA4627C626350031EF4C /* CoinList.storyboard */; };
 		08F5EA4A27C626E60031EF4C /* MoreDetail.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 08F5EA4927C626E60031EF4C /* MoreDetail.storyboard */; };
 		08F5EA4D27C627450031EF4C /* DepositWithdrawalStatus.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 08F5EA4C27C627450031EF4C /* DepositWithdrawalStatus.storyboard */; };
@@ -36,6 +37,7 @@
 /* Begin PBXFileReference section */
 		08AF803027C742AB00790762 /* APIProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIProtocol.swift; sourceTree = "<group>"; };
 		08AF803327C7452300790762 /* URLRequest+extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "URLRequest+extension.swift"; sourceTree = "<group>"; };
+		08AF803527C755A600790762 /* URLSession+extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "URLSession+extension.swift"; sourceTree = "<group>"; };
 		08F5EA4627C626350031EF4C /* CoinList.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = CoinList.storyboard; sourceTree = "<group>"; };
 		08F5EA4927C626E60031EF4C /* MoreDetail.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = MoreDetail.storyboard; sourceTree = "<group>"; };
 		08F5EA4C27C627450031EF4C /* DepositWithdrawalStatus.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = DepositWithdrawalStatus.storyboard; sourceTree = "<group>"; };
@@ -83,6 +85,7 @@
 			isa = PBXGroup;
 			children = (
 				08AF803327C7452300790762 /* URLRequest+extension.swift */,
+				08AF803527C755A600790762 /* URLSession+extension.swift */,
 			);
 			path = Extension;
 			sourceTree = "<group>";
@@ -306,6 +309,7 @@
 				08AF803427C7452300790762 /* URLRequest+extension.swift in Sources */,
 				37A15AD427C61D0A00585F4A /* BithumbYagomAcamedy.xcdatamodeld in Sources */,
 				37A15ACE27C61D0A00585F4A /* MainTabBarController.swift in Sources */,
+				08AF803627C755A600790762 /* URLSession+extension.swift in Sources */,
 				37A15ACA27C61D0A00585F4A /* AppDelegate.swift in Sources */,
 				08AF803127C742AB00790762 /* APIProtocol.swift in Sources */,
 				37A15ACC27C61D0A00585F4A /* SceneDelegate.swift in Sources */,

--- a/BithumbYagomAcamedy.xcodeproj/project.pbxproj
+++ b/BithumbYagomAcamedy.xcodeproj/project.pbxproj
@@ -10,6 +10,7 @@
 		08F5EA4727C626350031EF4C /* CoinList.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 08F5EA4627C626350031EF4C /* CoinList.storyboard */; };
 		08F5EA4A27C626E60031EF4C /* MoreDetail.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 08F5EA4927C626E60031EF4C /* MoreDetail.storyboard */; };
 		08F5EA4D27C627450031EF4C /* DepositWithdrawalStatus.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 08F5EA4C27C627450031EF4C /* DepositWithdrawalStatus.storyboard */; };
+		08F5EA5027C689710031EF4C /* NetworkService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08F5EA4F27C689710031EF4C /* NetworkService.swift */; };
 		37A15ACA27C61D0A00585F4A /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37A15AC927C61D0A00585F4A /* AppDelegate.swift */; };
 		37A15ACC27C61D0A00585F4A /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37A15ACB27C61D0A00585F4A /* SceneDelegate.swift */; };
 		37A15ACE27C61D0A00585F4A /* MainTabBarController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37A15ACD27C61D0A00585F4A /* MainTabBarController.swift */; };
@@ -34,6 +35,7 @@
 		08F5EA4627C626350031EF4C /* CoinList.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = CoinList.storyboard; sourceTree = "<group>"; };
 		08F5EA4927C626E60031EF4C /* MoreDetail.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = MoreDetail.storyboard; sourceTree = "<group>"; };
 		08F5EA4C27C627450031EF4C /* DepositWithdrawalStatus.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = DepositWithdrawalStatus.storyboard; sourceTree = "<group>"; };
+		08F5EA4F27C689710031EF4C /* NetworkService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkService.swift; sourceTree = "<group>"; };
 		37A15AC627C61D0A00585F4A /* BithumbYagomAcamedy.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = BithumbYagomAcamedy.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		37A15AC927C61D0A00585F4A /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		37A15ACB27C61D0A00585F4A /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -128,6 +130,14 @@
 			path = DepositWithdrawalStatusView;
 			sourceTree = "<group>";
 		};
+		08F5EA4E27C688160031EF4C /* Utility */ = {
+			isa = PBXGroup;
+			children = (
+				08F5EA4F27C689710031EF4C /* NetworkService.swift */,
+			);
+			path = Utility;
+			sourceTree = "<group>";
+		};
 		37A15ABD27C61D0A00585F4A = {
 			isa = PBXGroup;
 			children = (
@@ -149,6 +159,7 @@
 		37A15AC827C61D0A00585F4A /* BithumbYagomAcamedy */ = {
 			isa = PBXGroup;
 			children = (
+				08F5EA4E27C688160031EF4C /* Utility */,
 				08F5EA4327C623EE0031EF4C /* AppLifeCycle */,
 				08F5EA4127C622F60031EF4C /* Resource */,
 				08F5EA4427C6240C0031EF4C /* Controller */,
@@ -269,6 +280,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				08F5EA5027C689710031EF4C /* NetworkService.swift in Sources */,
 				37A15AD427C61D0A00585F4A /* BithumbYagomAcamedy.xcdatamodeld in Sources */,
 				37A15ACE27C61D0A00585F4A /* MainTabBarController.swift in Sources */,
 				37A15ACA27C61D0A00585F4A /* AppDelegate.swift in Sources */,

--- a/BithumbYagomAcamedy/Extension/URLRequest+extension.swift
+++ b/BithumbYagomAcamedy/Extension/URLRequest+extension.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 extension URLRequest {
-    init?(api: APIProtocol) {
+    init?(api: APIable) {
         guard let url = api.url else {
             return nil
         }

--- a/BithumbYagomAcamedy/Extension/URLRequest+extension.swift
+++ b/BithumbYagomAcamedy/Extension/URLRequest+extension.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 extension URLRequest {
-    init?(api: Gettable) {
+    init?(api: APIProtocol) {
         guard let url = api.url else {
             return nil
         }

--- a/BithumbYagomAcamedy/Extension/URLRequest+extension.swift
+++ b/BithumbYagomAcamedy/Extension/URLRequest+extension.swift
@@ -1,0 +1,19 @@
+//
+//  URLRequest+extension.swift
+//  BithumbYagomAcamedy
+//
+//  Created by 황제하 on 2022/02/24.
+//
+
+import Foundation
+
+extension URLRequest {
+    init?(api: Gettable) {
+        guard let url = api.url else {
+            return nil
+        }
+        
+        self.init(url: url)
+        self.httpMethod = "\(api.method)"
+    }
+}

--- a/BithumbYagomAcamedy/Extension/URLSession+extension.swift
+++ b/BithumbYagomAcamedy/Extension/URLSession+extension.swift
@@ -7,10 +7,11 @@
 
 import Foundation
 
-protocol URLSessionProtocol {
-    func dataTask(with request: URLRequest,
-                  completionHandler: @escaping (Data?, URLResponse?, Error?) -> Void
+protocol URLSessionProviding {
+    func dataTask(
+        with request: URLRequest,
+        completionHandler: @escaping (Data?, URLResponse?, Error?) -> Void
     ) -> URLSessionDataTask
 }
 
-extension URLSession: URLSessionProtocol { }
+extension URLSession: URLSessionProviding { }

--- a/BithumbYagomAcamedy/Extension/URLSession+extension.swift
+++ b/BithumbYagomAcamedy/Extension/URLSession+extension.swift
@@ -1,0 +1,16 @@
+//
+//  URLSession+extension.swift
+//  BithumbYagomAcamedy
+//
+//  Created by 황제하 on 2022/02/24.
+//
+
+import Foundation
+
+protocol URLSessionProtocol {
+    func dataTask(with request: URLRequest,
+                  completionHandler: @escaping (Data?, URLResponse?, Error?) -> Void
+    ) -> URLSessionDataTask
+}
+
+extension URLSession: URLSessionProtocol { }

--- a/BithumbYagomAcamedy/Protocol/APIProtocol.swift
+++ b/BithumbYagomAcamedy/Protocol/APIProtocol.swift
@@ -12,6 +12,8 @@ protocol APIProtocol {
     var method: HTTPMethod { get }
 }
 
+protocol Gettable: APIProtocol { }
+
 enum HTTPMethod: CustomStringConvertible {
     case get
     

--- a/BithumbYagomAcamedy/Protocol/APIProtocol.swift
+++ b/BithumbYagomAcamedy/Protocol/APIProtocol.swift
@@ -9,5 +9,16 @@ import Foundation
 
 protocol APIProtocol {
     var url: URL? { get }
-    var method: String { get }
+    var method: HTTPMethod { get }
+}
+
+enum HTTPMethod: CustomStringConvertible {
+    case get
+    
+    var description: String {
+        switch self {
+        case .get:
+            return "GET"
+        }
+    }
 }

--- a/BithumbYagomAcamedy/Protocol/APIProtocol.swift
+++ b/BithumbYagomAcamedy/Protocol/APIProtocol.swift
@@ -1,0 +1,13 @@
+//
+//  APIProtocol.swift
+//  BithumbYagomAcamedy
+//
+//  Created by 황제하 on 2022/02/24.
+//
+
+import Foundation
+
+protocol APIProtocol {
+    var url: URL? { get }
+    var method: String { get }
+}

--- a/BithumbYagomAcamedy/Protocol/APIable.swift
+++ b/BithumbYagomAcamedy/Protocol/APIable.swift
@@ -7,12 +7,12 @@
 
 import Foundation
 
-protocol APIProtocol {
+protocol APIable {
     var url: URL? { get }
     var method: HTTPMethod { get }
 }
 
-protocol Gettable: APIProtocol { }
+protocol Gettable: APIable { }
 
 enum HTTPMethod: CustomStringConvertible {
     case get

--- a/BithumbYagomAcamedy/Utility/NetworkService.swift
+++ b/BithumbYagomAcamedy/Utility/NetworkService.swift
@@ -29,9 +29,9 @@ enum NetworkError: LocalizedError, Equatable {
 }
 
 struct NetworkService {
-    private let session: URLSessionProtocol
+    private let session: URLSessionProviding
     
-    init(session: URLSessionProtocol = URLSession.shared) {
+    init(session: URLSessionProviding = URLSession.shared) {
         self.session = session
     }
     
@@ -63,7 +63,7 @@ struct NetworkService {
     }
     
     func request(
-        api: APIProtocol,
+        api: APIable,
         completionHandler: @escaping ((Result<Data, NetworkError>) -> Void)
     ) {
         guard let urlRequest = URLRequest(api: api) else {

--- a/BithumbYagomAcamedy/Utility/NetworkService.swift
+++ b/BithumbYagomAcamedy/Utility/NetworkService.swift
@@ -60,8 +60,8 @@ struct NetworkService {
     
     func request(
         urlRequest: APIProtocol,
-        completionHandler: @escaping ((Result<Data, NetworkError>) -> Void))
-    {
+        completionHandler: @escaping ((Result<Data, NetworkError>) -> Void)
+    ) {
         guard let urlRequest = URLRequest(api: urlRequest) else {
             completionHandler(.failure(.urlIsNil))
             return

--- a/BithumbYagomAcamedy/Utility/NetworkService.swift
+++ b/BithumbYagomAcamedy/Utility/NetworkService.swift
@@ -7,7 +7,11 @@
 
 import Foundation
 
-enum NetworkError: LocalizedError {
+enum NetworkError: LocalizedError, Equatable {
+    static func == (lhs: NetworkError, rhs: NetworkError) -> Bool {
+        return lhs.errorDescription == rhs.errorDescription
+    }
+    
     case statusCodeError
     case urlIsNil
     case unknown(error: Error)
@@ -25,9 +29,9 @@ enum NetworkError: LocalizedError {
 }
 
 struct NetworkService {
-    private let session: URLSession
+    private let session: URLSessionProtocol
     
-    init(session: URLSession = URLSession.shared) {
+    init(session: URLSessionProtocol = URLSession.shared) {
         self.session = session
     }
     
@@ -59,10 +63,10 @@ struct NetworkService {
     }
     
     func request(
-        urlRequest: APIProtocol,
+        api: APIProtocol,
         completionHandler: @escaping ((Result<Data, NetworkError>) -> Void)
     ) {
-        guard let urlRequest = URLRequest(api: urlRequest) else {
+        guard let urlRequest = URLRequest(api: api) else {
             completionHandler(.failure(.urlIsNil))
             return
         }

--- a/BithumbYagomAcamedy/Utility/NetworkService.swift
+++ b/BithumbYagomAcamedy/Utility/NetworkService.swift
@@ -54,4 +54,10 @@ struct NetworkService {
         }
         task.resume()
     }
+    
+    func request(
+        urlRequest: URLRequest,
+        completionHandler: @escaping ((Result<Data, NetworkError>) -> Void)) {
+        loadData(urlRequest: urlRequest, completionHandler: completionHandler)
+    }
 }

--- a/BithumbYagomAcamedy/Utility/NetworkService.swift
+++ b/BithumbYagomAcamedy/Utility/NetworkService.swift
@@ -7,11 +7,7 @@
 
 import Foundation
 
-enum NetworkError: LocalizedError, Equatable {
-    static func == (lhs: NetworkError, rhs: NetworkError) -> Bool {
-        return lhs.errorDescription == rhs.errorDescription
-    }
-    
+enum NetworkError: LocalizedError {    
     case statusCodeError
     case invalidURLRequest
     case unknown(error: Error)

--- a/BithumbYagomAcamedy/Utility/NetworkService.swift
+++ b/BithumbYagomAcamedy/Utility/NetworkService.swift
@@ -7,10 +7,51 @@
 
 import Foundation
 
+enum NetworkError: LocalizedError {
+    case statusCodeError
+    case unknown(error: Error)
+
+    var errorDescription: String? {
+        switch self {
+        case .statusCodeError:
+            return "정상적인 StatusCode가 아닙니다."
+        case .unknown(let error):
+            return "\(error.localizedDescription) 에러가 발생했습니다."
+        }
+    }
+}
+
 struct NetworkService {
     private let session: URLSession
     
     init(session: URLSession = URLSession.shared) {
         self.session = session
+    }
+    
+    private func loadData(
+        urlRequest: URLRequest,
+        completionHandler: @escaping ((Result<Data, NetworkError>) -> Void)
+    ) {
+        let task = session.dataTask(with: urlRequest) { data, response, error in
+            if let error = error {
+                completionHandler(.failure(.unknown(error: error)))
+                return
+            }
+            
+            let successStatusCode = 200..<300
+            
+            guard let httpResponse = response as? HTTPURLResponse,
+                  successStatusCode.contains(httpResponse.statusCode)
+            else {
+                completionHandler(.failure(.statusCodeError))
+                return
+            }
+            
+            if let data = data {
+                completionHandler(.success(data))
+                return
+            }
+        }
+        task.resume()
     }
 }

--- a/BithumbYagomAcamedy/Utility/NetworkService.swift
+++ b/BithumbYagomAcamedy/Utility/NetworkService.swift
@@ -13,15 +13,15 @@ enum NetworkError: LocalizedError, Equatable {
     }
     
     case statusCodeError
-    case urlIsNil
+    case invalidURLRequest
     case unknown(error: Error)
 
     var errorDescription: String? {
         switch self {
         case .statusCodeError:
             return "정상적인 StatusCode가 아닙니다."
-        case .urlIsNil:
-            return "정상적인 URL이 아닙니다."
+        case .invalidURLRequest:
+            return "정상적인 URLRequest가 아닙니다."
         case .unknown(let error):
             return "\(error.localizedDescription) 에러가 발생했습니다."
         }
@@ -67,7 +67,7 @@ struct NetworkService {
         completionHandler: @escaping ((Result<Data, NetworkError>) -> Void)
     ) {
         guard let urlRequest = URLRequest(api: api) else {
-            completionHandler(.failure(.urlIsNil))
+            completionHandler(.failure(.invalidURLRequest))
             return
         }
         loadData(urlRequest: urlRequest, completionHandler: completionHandler)

--- a/BithumbYagomAcamedy/Utility/NetworkService.swift
+++ b/BithumbYagomAcamedy/Utility/NetworkService.swift
@@ -1,0 +1,16 @@
+//
+//  NetworkService.swift
+//  BithumbYagomAcamedy
+//
+//  Created by 황제하 on 2022/02/24.
+//
+
+import Foundation
+
+struct NetworkService {
+    private let session: URLSession
+    
+    init(session: URLSession = URLSession.shared) {
+        self.session = session
+    }
+}

--- a/BithumbYagomAcamedy/Utility/NetworkService.swift
+++ b/BithumbYagomAcamedy/Utility/NetworkService.swift
@@ -9,12 +9,15 @@ import Foundation
 
 enum NetworkError: LocalizedError {
     case statusCodeError
+    case urlIsNil
     case unknown(error: Error)
 
     var errorDescription: String? {
         switch self {
         case .statusCodeError:
             return "정상적인 StatusCode가 아닙니다."
+        case .urlIsNil:
+            return "정상적인 URL이 아닙니다."
         case .unknown(let error):
             return "\(error.localizedDescription) 에러가 발생했습니다."
         }
@@ -56,8 +59,13 @@ struct NetworkService {
     }
     
     func request(
-        urlRequest: URLRequest,
-        completionHandler: @escaping ((Result<Data, NetworkError>) -> Void)) {
+        urlRequest: APIProtocol,
+        completionHandler: @escaping ((Result<Data, NetworkError>) -> Void))
+    {
+        guard let urlRequest = URLRequest(api: urlRequest) else {
+            completionHandler(.failure(.urlIsNil))
+            return
+        }
         loadData(urlRequest: urlRequest, completionHandler: completionHandler)
     }
 }

--- a/BithumbYagomAcamedyTests/NetworkServiceTest/Mock/MockURLSession.swift
+++ b/BithumbYagomAcamedyTests/NetworkServiceTest/Mock/MockURLSession.swift
@@ -20,7 +20,7 @@ enum MockNetworkError: Error {
     case mockError
 }
 
-final class MockURLSession: URLSessionProtocol {
+final class MockURLSession: URLSessionProviding {
     private let isSuccess: Bool
     private let error: MockNetworkError?
     

--- a/BithumbYagomAcamedyTests/NetworkServiceTest/Mock/MockURLSession.swift
+++ b/BithumbYagomAcamedyTests/NetworkServiceTest/Mock/MockURLSession.swift
@@ -16,11 +16,17 @@ final class MockURLSessionDataTask: URLSessionDataTask {
     }
 }
 
+enum MockNetworkError: Error {
+    case mockError
+}
+
 final class MockURLSession: URLSessionProtocol {
     private let isSuccess: Bool
+    private let error: MockNetworkError?
     
-    init(isSuccess: Bool = true) {
+    init(isSuccess: Bool = true, error: MockNetworkError? = nil) {
         self.isSuccess = isSuccess
+        self.error = error
     }
     
     func dataTask(
@@ -49,12 +55,12 @@ final class MockURLSession: URLSessionProtocol {
         let sessionDataTask = MockURLSessionDataTask()
         
         if isSuccess {
-            sessionDataTask.resumeDidCall = {
-                completionHandler(data, successResponse, nil)
+            sessionDataTask.resumeDidCall = { [weak self] in
+                completionHandler(data, successResponse, self?.error)
             }
         } else {
-            sessionDataTask.resumeDidCall = {
-                completionHandler(nil, failureResponse, nil)
+            sessionDataTask.resumeDidCall = { [weak self] in
+                completionHandler(nil, failureResponse, self?.error)
             }
         }
         

--- a/BithumbYagomAcamedyTests/NetworkServiceTest/Mock/MockURLSession.swift
+++ b/BithumbYagomAcamedyTests/NetworkServiceTest/Mock/MockURLSession.swift
@@ -1,0 +1,63 @@
+//
+//  MockURLSession.swift
+//  BithumbYagomAcamedyTests
+//
+//  Created by 황제하 on 2022/02/24.
+//
+
+import Foundation
+@testable import BithumbYagomAcamedy
+
+final class MockURLSessionDataTask: URLSessionDataTask {
+    var resumeDidCall: () -> Void = {}
+
+    override func resume() {
+        resumeDidCall()
+    }
+}
+
+final class MockURLSession: URLSessionProtocol {
+    private let isSuccess: Bool
+    
+    init(isSuccess: Bool = true) {
+        self.isSuccess = isSuccess
+    }
+    
+    func dataTask(
+        with request: URLRequest,
+        completionHandler: @escaping (Data?, URLResponse?, Error?) -> Void
+    ) -> URLSessionDataTask {
+        guard let url = request.url else {
+            return URLSessionDataTask()
+        }
+        
+        let successResponse = HTTPURLResponse(
+            url: url,
+            statusCode: 200,
+            httpVersion: "1.1",
+            headerFields: nil
+        )
+        let failureResponse = HTTPURLResponse(
+            url: url,
+            statusCode: 400,
+            httpVersion: "1.1",
+            headerFields: nil
+        )
+        
+        let dataString = #""OK""#
+        let data = dataString.data(using: .utf8)
+        let sessionDataTask = MockURLSessionDataTask()
+        
+        if isSuccess {
+            sessionDataTask.resumeDidCall = {
+                completionHandler(data, successResponse, nil)
+            }
+        } else {
+            sessionDataTask.resumeDidCall = {
+                completionHandler(nil, failureResponse, nil)
+            }
+        }
+        
+        return sessionDataTask
+    }
+}

--- a/BithumbYagomAcamedyTests/NetworkServiceTest/NetworkServiceTests.swift
+++ b/BithumbYagomAcamedyTests/NetworkServiceTest/NetworkServiceTests.swift
@@ -82,4 +82,18 @@ class NetworkServiceTests: XCTestCase {
             }
         }
     }
+    
+    func test_MockURLSession의_MockError을_담아보냈을때_MockError을_반환하는지() {
+        let mockSession = MockURLSession(isSuccess: false, error: .mockError)
+        networkService = NetworkService(session: mockSession)
+        
+        networkService.request(api: mockAPI) { result in
+            switch result {
+            case .success(_):
+                XCTFail()
+            case .failure(let error):
+                XCTAssertEqual(error, .unknown(error: MockNetworkError.mockError))
+            }
+        }
+    }
 }

--- a/BithumbYagomAcamedyTests/NetworkServiceTest/NetworkServiceTests.swift
+++ b/BithumbYagomAcamedyTests/NetworkServiceTest/NetworkServiceTests.swift
@@ -1,0 +1,42 @@
+//
+//  NetworkServiceTests.swift
+//  BithumbYagomAcamedyTests
+//
+//  Created by 황제하 on 2022/02/24.
+//
+
+import XCTest
+@testable import BithumbYagomAcamedy
+
+struct MockAPI: Gettable {
+    var url: URL?
+    var method: HTTPMethod = .get
+}
+
+class NetworkServiceTests: XCTestCase {
+    var networkService: NetworkService!
+    var mockAPI: MockAPI!
+    
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+        networkService = NetworkService()
+        mockAPI = MockAPI(url: URL(string: "www"), method: .get)
+    }
+
+    override func tearDownWithError() throws {
+        try super.tearDownWithError()
+        networkService = nil
+        mockAPI = nil
+    }
+    
+    func test_URL이_유효하지않을때_statusCodeError가_나오는지() {
+        networkService.request(api: mockAPI) { result in
+            switch result {
+            case .success(_):
+                XCTFail()
+            case .failure(let error):
+                XCTAssertEqual(error, .statusCodeError)
+            }
+        }
+    }
+}

--- a/BithumbYagomAcamedyTests/NetworkServiceTest/NetworkServiceTests.swift
+++ b/BithumbYagomAcamedyTests/NetworkServiceTest/NetworkServiceTests.swift
@@ -39,4 +39,17 @@ class NetworkServiceTests: XCTestCase {
             }
         }
     }
+    
+    func test_URL이_Nil일때_urlIsNil에러가_나오는지() {
+        mockAPI = MockAPI()
+        
+        networkService.request(api: mockAPI) { result in
+            switch result {
+            case .success(_):
+                XCTFail()
+            case .failure(let error):
+                XCTAssertEqual(error, .urlIsNil)
+            }
+        }
+    }
 }

--- a/BithumbYagomAcamedyTests/NetworkServiceTest/NetworkServiceTests.swift
+++ b/BithumbYagomAcamedyTests/NetworkServiceTest/NetworkServiceTests.swift
@@ -35,15 +35,19 @@ class NetworkServiceTests: XCTestCase {
         mockAPI = nil
     }
     
-    func test_URL이_유효하지않을때_statusCodeError가_나오는지() {
+    func test_URL이_유효하지않을때_Error가_나오는지() {
+        let expectation = XCTestExpectation()
+            
         networkService.request(api: mockAPI) { result in
             switch result {
             case .success(_):
                 XCTFail()
             case .failure(let error):
-                XCTAssertEqual(error, .statusCodeError)
+                XCTAssertNotNil(error)
             }
+            expectation.fulfill()
         }
+        wait(for: [expectation], timeout: 3)
     }
     
     func test_URL이_Nil일때_invalidURLRequest에러가_나오는지() {
@@ -84,7 +88,7 @@ class NetworkServiceTests: XCTestCase {
             case .success(_):
                 XCTFail()
             case .failure(let error):
-                XCTAssertEqual(error, .statusCodeError)
+                XCTAssertEqual(error, .statusCodeError(400))
             }
         }
     }

--- a/BithumbYagomAcamedyTests/NetworkServiceTest/NetworkServiceTests.swift
+++ b/BithumbYagomAcamedyTests/NetworkServiceTest/NetworkServiceTests.swift
@@ -40,7 +40,7 @@ class NetworkServiceTests: XCTestCase {
         }
     }
     
-    func test_URL이_Nil일때_urlIsNil에러가_나오는지() {
+    func test_URL이_Nil일때_invalidURLRequest에러가_나오는지() {
         mockAPI = MockAPI()
         
         networkService.request(api: mockAPI) { result in
@@ -48,7 +48,7 @@ class NetworkServiceTests: XCTestCase {
             case .success(_):
                 XCTFail()
             case .failure(let error):
-                XCTAssertEqual(error, .urlIsNil)
+                XCTAssertEqual(error, .invalidURLRequest)
             }
         }
     }
@@ -78,7 +78,7 @@ class NetworkServiceTests: XCTestCase {
             case .success(_):
                 XCTFail()
             case .failure(let error):
-                XCTAssertEqual(error, NetworkError.statusCodeError)
+                XCTAssertEqual(error, .statusCodeError)
             }
         }
     }

--- a/BithumbYagomAcamedyTests/NetworkServiceTest/NetworkServiceTests.swift
+++ b/BithumbYagomAcamedyTests/NetworkServiceTest/NetworkServiceTests.swift
@@ -8,6 +8,12 @@
 import XCTest
 @testable import BithumbYagomAcamedy
 
+extension NetworkError: Equatable {
+    public static func == (lhs: NetworkError, rhs: NetworkError) -> Bool {
+        return lhs.errorDescription == rhs.errorDescription
+    }
+}
+
 struct MockAPI: Gettable {
     var url: URL?
     var method: HTTPMethod = .get

--- a/BithumbYagomAcamedyTests/NetworkServiceTest/NetworkServiceTests.swift
+++ b/BithumbYagomAcamedyTests/NetworkServiceTest/NetworkServiceTests.swift
@@ -68,4 +68,18 @@ class NetworkServiceTests: XCTestCase {
             }
         }
     }
+    
+    func test_MockURLSession의_isSuccess가_false일때_실패하는지() {
+        let mockSession = MockURLSession(isSuccess: false)
+        networkService = NetworkService(session: mockSession)
+        
+        networkService.request(api: mockAPI) { result in
+            switch result {
+            case .success(_):
+                XCTFail()
+            case .failure(let error):
+                XCTAssertEqual(error, NetworkError.statusCodeError)
+            }
+        }
+    }
 }

--- a/BithumbYagomAcamedyTests/NetworkServiceTest/NetworkServiceTests.swift
+++ b/BithumbYagomAcamedyTests/NetworkServiceTest/NetworkServiceTests.swift
@@ -52,4 +52,20 @@ class NetworkServiceTests: XCTestCase {
             }
         }
     }
+    
+    func test_MockURLSession의_isSuccess가_true일때_정상동작_하는지() {
+        let mockSession = MockURLSession(isSuccess: true)
+        networkService = NetworkService(session: mockSession)
+        
+        networkService.request(api: mockAPI) { result in
+            switch result {
+            case .success(let data):
+                let resultString = String(data: data, encoding: .utf8)
+                let successString = #""OK""#
+                XCTAssertEqual(resultString, successString)
+            case .failure(_):
+                XCTFail()
+            }
+        }
+    }
 }


### PR DESCRIPTION
### 구현 내용
- NetworkService : 네트워트 통신을 위한 구조체
  - loadData() : task를 만들고 completionHandler로 Response을 가공하는 메서드
  - request() : 요청을 보내는 메서드
- NetworkError : 네트워크 통신 에러 열거형
- Gettable Protocol : 기능별(Ticker, Orderbook 등) API(GET) 타입을 생성할 때 채택하는 프로토콜
   -  APIProtocol을 상속받음
- URLRequest+extension
  - APIProtocol을 매개변수로 받는 init?() 확장
- URLSession+extension
  - 실제 네트워크 통신에 의존하지 않는 테스트를 위한 URLSessionProtocol 채택
 
- MockURLSession
  - 실제 네트워크 통신에 의존하지 않는 테스트를 위한 타입
- NetworkServiceTests
  - URL이 유효하지않을때 statusCodeError가 나오는지
  - URL이 Nil일때 invalidURLRequest에러가 나오는지
  - MockURLSession의 isSuccess가 true일때 정상동작 하는지
  - MockURLSession의 isSuccess가 false일때 실패하는지
  - MockURLSession의 MockError을 담아보냈을때 MockError을 반환하는지
  Unit Test 진행
  - Unit Test 결과
    <img width="356" alt="스크린샷 2022-02-24 오후 6 06 41" src="https://user-images.githubusercontent.com/98801129/155493285-384778ff-4a9c-484b-8c1d-ccccbaea4f09.png">
