### PR TITLE
Bithumb assets status API를 이용한 입출금 현황 화면 갱신 기능 추가

### DIFF
--- a/BithumbYagomAcamedy.xcodeproj/project.pbxproj
+++ b/BithumbYagomAcamedy.xcodeproj/project.pbxproj
@@ -27,6 +27,8 @@
 		3707833527C8B88F009ECBBC /* OrderbookJSONFile.json in Resources */ = {isa = PBXBuildFile; fileRef = 3707833027C8B88F009ECBBC /* OrderbookJSONFile.json */; };
 		3707833627C8B88F009ECBBC /* AssetsStatusJSONFile.json in Resources */ = {isa = PBXBuildFile; fileRef = 3707833127C8B88F009ECBBC /* AssetsStatusJSONFile.json */; };
 		3707833827C8C469009ECBBC /* DepositWithdrawalStatusViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3707833727C8C469009ECBBC /* DepositWithdrawalStatusViewController.swift */; };
+		370C4B2127CC688800EE2C68 /* DepositWithdrawalStatusDataManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 370C4B2027CC688800EE2C68 /* DepositWithdrawalStatusDataManager.swift */; };
+		370C4B2327CC6BA700EE2C68 /* AssetsStatus.swift in Sources */ = {isa = PBXBuildFile; fileRef = 370C4B2227CC6BA700EE2C68 /* AssetsStatus.swift */; };
 		371D996F27C755C7000368AC /* JSONParserTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 371D996E27C755C7000368AC /* JSONParserTests.swift */; };
 		371D997B27C77C5E000368AC /* CoinListCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 371D997927C77C5E000368AC /* CoinListCollectionViewCell.swift */; };
 		371D997C27C77C5E000368AC /* CoinListCollectionViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 371D997A27C77C5E000368AC /* CoinListCollectionViewCell.xib */; };
@@ -79,6 +81,8 @@
 		3707833027C8B88F009ECBBC /* OrderbookJSONFile.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = OrderbookJSONFile.json; sourceTree = "<group>"; };
 		3707833127C8B88F009ECBBC /* AssetsStatusJSONFile.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = AssetsStatusJSONFile.json; sourceTree = "<group>"; };
 		3707833727C8C469009ECBBC /* DepositWithdrawalStatusViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DepositWithdrawalStatusViewController.swift; sourceTree = "<group>"; };
+		370C4B2027CC688800EE2C68 /* DepositWithdrawalStatusDataManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DepositWithdrawalStatusDataManager.swift; sourceTree = "<group>"; };
+		370C4B2227CC6BA700EE2C68 /* AssetsStatus.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AssetsStatus.swift; sourceTree = "<group>"; };
 		371D996E27C755C7000368AC /* JSONParserTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JSONParserTests.swift; sourceTree = "<group>"; };
 		371D997927C77C5E000368AC /* CoinListCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoinListCollectionViewCell.swift; sourceTree = "<group>"; };
 		371D997A27C77C5E000368AC /* CoinListCollectionViewCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = CoinListCollectionViewCell.xib; sourceTree = "<group>"; };
@@ -321,6 +325,8 @@
 			children = (
 				08AF806727C8AFDB00790762 /* BithumbPublicAPI */,
 				3CCB27C627C73E4D00F84C80 /* ValueObject */,
+				370C4B2227CC6BA700EE2C68 /* AssetsStatus.swift */,
+				370C4B2027CC688800EE2C68 /* DepositWithdrawalStatusDataManager.swift */,
 			);
 			path = Model;
 			sourceTree = "<group>";
@@ -452,8 +458,10 @@
 				08F5EA5027C689710031EF4C /* NetworkService.swift in Sources */,
 				08AF803427C7452300790762 /* URLRequest+extension.swift in Sources */,
 				3CCB27C827C7473D00F84C80 /* TickersValueObject.swift in Sources */,
+				370C4B2127CC688800EE2C68 /* DepositWithdrawalStatusDataManager.swift in Sources */,
 				3CCB27CE27C77F0D00F84C80 /* TransactionValueObject.swift in Sources */,
 				3CCB27CC27C77EA500F84C80 /* OrderbookValueObject.swift in Sources */,
+				370C4B2327CC6BA700EE2C68 /* AssetsStatus.swift in Sources */,
 				3CC98F3827C879F200B9A6EF /* CoinListViewController.swift in Sources */,
 				08AF806927C8AFFF00790762 /* BithumbPublicAPI.swift in Sources */,
 				08AF806C27C8BD9300790762 /* GETMethods.swift in Sources */,

--- a/BithumbYagomAcamedy/Controller/DepositWithdrawalStatusViewController.swift
+++ b/BithumbYagomAcamedy/Controller/DepositWithdrawalStatusViewController.swift
@@ -32,6 +32,7 @@ final class DepositWithdrawalStatusViewController: UIViewController {
         configureCollectionViewLayout()
         configureDiffableDataSource()
         configureDataManager()
+        applyDepositWithdrawalStatusData()
     }
     
     // MARK: - Configuration
@@ -44,7 +45,10 @@ final class DepositWithdrawalStatusViewController: UIViewController {
     }
     
     private func configureDiffableDataSource() {
-        typealias CellRegistration = UICollectionView.CellRegistration<DepositWithdrawalCollectionViewCell, AssetsStatus>
+        typealias CellRegistration = UICollectionView.CellRegistration<
+            DepositWithdrawalCollectionViewCell, AssetsStatus
+        >
+        
         let depositWithdrawalCell = UINib(nibName: depositWithdrawalCollectionViewCellNibName, bundle: nil)
         let cellRegistration = CellRegistration(cellNib: depositWithdrawalCell) { cell, indexPath, item in
             cell.update(item)
@@ -53,13 +57,19 @@ final class DepositWithdrawalStatusViewController: UIViewController {
         dataSource = UICollectionViewDiffableDataSource<Section, AssetsStatus>(
             collectionView: collectionView
         ) { collectionView, indexPath, data -> UICollectionViewCell? in
-            return collectionView.dequeueConfiguredReusableCell(using: cellRegistration, for: indexPath, item: data)
+            return collectionView.dequeueConfiguredReusableCell(
+                using: cellRegistration,
+                for: indexPath,
+                item: data
+            )
         }
     }
     
     private func configureDataManager() {
         dataManager = DepositWithdrawalStatusDataManager()
-        
+    }
+    
+    private func applyDepositWithdrawalStatusData() {
         dataManager?.requestData { [weak self] assetsStatuses in
             var snapshot = NSDiffableDataSourceSnapshot<Section, AssetsStatus>()
             

--- a/BithumbYagomAcamedy/Controller/DepositWithdrawalStatusViewController.swift
+++ b/BithumbYagomAcamedy/Controller/DepositWithdrawalStatusViewController.swift
@@ -15,33 +15,14 @@ final class DepositWithdrawalStatusViewController: UIViewController {
         case main
     }
     
-    // MARK: - Nested Type
-    
-    struct MockData: DepositWithdrawalCellDataProviding, Hashable {
-        private(set) var coinName: String
-        private(set) var coinSymbol: String
-        private(set) var depositStatus: String
-        private(set) var withdrawalStatus: String
-        private(set) var isValidDeposit: Bool
-        private(set) var isValidWithdrawal: Bool
-        let uuid: UUID = UUID()
-        
-        func hash(into hasher: inout Hasher) {
-            hasher.combine(uuid)
-        }
-        
-        static func ==(lhs: MockData, rhs: MockData) -> Bool {
-            return lhs.uuid == rhs.uuid
-        }
-    }
-    
     // MARK: - IBOutlet
     
     @IBOutlet private weak var collectionView: UICollectionView!
     
     // MARK: - Property
     
-    private var dataSource: UICollectionViewDiffableDataSource<Section, MockData>?
+    private var dataManager: DepositWithdrawalStatusDataManager?
+    private var dataSource: UICollectionViewDiffableDataSource<Section, AssetsStatus>?
     private let depositWithdrawalCollectionViewCellNibName = "DepositWithdrawalCollectionViewCell"
     
     // MARK: - Life Cycle
@@ -50,7 +31,7 @@ final class DepositWithdrawalStatusViewController: UIViewController {
         super.viewDidLoad()
         configureCollectionViewLayout()
         configureDiffableDataSource()
-        configureMockData()
+        configureDataManager()
     }
     
     // MARK: - Configuration
@@ -63,57 +44,28 @@ final class DepositWithdrawalStatusViewController: UIViewController {
     }
     
     private func configureDiffableDataSource() {
-        typealias CellRegistration = UICollectionView.CellRegistration<DepositWithdrawalCollectionViewCell, MockData>
-        
+        typealias CellRegistration = UICollectionView.CellRegistration<DepositWithdrawalCollectionViewCell, AssetsStatus>
         let depositWithdrawalCell = UINib(nibName: depositWithdrawalCollectionViewCellNibName, bundle: nil)
         let cellRegistration = CellRegistration(cellNib: depositWithdrawalCell) { cell, indexPath, item in
             cell.update(item)
         }
-        dataSource = UICollectionViewDiffableDataSource<Section, MockData>(collectionView: collectionView) { collectionView, indexPath, data -> UICollectionViewCell? in
+        
+        dataSource = UICollectionViewDiffableDataSource<Section, AssetsStatus>(
+            collectionView: collectionView
+        ) { collectionView, indexPath, data -> UICollectionViewCell? in
             return collectionView.dequeueConfiguredReusableCell(using: cellRegistration, for: indexPath, item: data)
         }
     }
     
-    private func configureMockData() {
-        var snapshot = NSDiffableDataSourceSnapshot<Section, MockData>()
-        snapshot.appendSections([.main])
+    private func configureDataManager() {
+        dataManager = DepositWithdrawalStatusDataManager()
         
-        snapshot.appendItems([MockData(
-                                coinName: "비트코인",
-                                coinSymbol: "BTC/KRW",
-                                depositStatus: "정상",
-                                withdrawalStatus: "정상",
-                                isValidDeposit: true,
-                                isValidWithdrawal: true),
-                              MockData(
-                                coinName: "이더리움",
-                                coinSymbol: "ETH/KRW",
-                                depositStatus: "정상",
-                                withdrawalStatus: "중단",
-                                isValidDeposit: true,
-                                isValidWithdrawal: false),
-                              MockData(
-                                coinName: "Test1",
-                                coinSymbol: "TST/KRW",
-                                depositStatus: "정상",
-                                withdrawalStatus: "정상",
-                                isValidDeposit: true,
-                                isValidWithdrawal: true),
-                              MockData(
-                                coinName: "Test2",
-                                coinSymbol: "TST/KRW",
-                                depositStatus: "정상",
-                                withdrawalStatus: "중단",
-                                isValidDeposit: true,
-                                isValidWithdrawal: false),
-                              MockData(
-                                coinName: "Test3",
-                                coinSymbol: "TST/KRW",
-                                depositStatus: "중단",
-                                withdrawalStatus: "중단",
-                                isValidDeposit: false,
-                                isValidWithdrawal: false)
-                             ])
-        dataSource?.apply(snapshot)
+        dataManager?.requestData { [weak self] assetsStatuses in
+            var snapshot = NSDiffableDataSourceSnapshot<Section, AssetsStatus>()
+            
+            snapshot.appendSections([.main])
+            snapshot.appendItems(assetsStatuses, toSection: .main)
+            self?.dataSource?.apply(snapshot)
+        }
     }
 }

--- a/BithumbYagomAcamedy/Model/AssetsStatus.swift
+++ b/BithumbYagomAcamedy/Model/AssetsStatus.swift
@@ -1,0 +1,26 @@
+//
+//  AssetsStatus.swift
+//  BithumbYagomAcamedy
+//
+//  Created by Oh Donggeon on 2022/02/28.
+//
+
+import Foundation
+
+struct AssetsStatus: DepositWithdrawalCellDataProviding, Hashable {
+    private(set) var coinName: String
+    private(set) var coinSymbol: String
+    private(set) var depositStatus: String
+    private(set) var withdrawalStatus: String
+    private(set) var isValidDeposit: Bool
+    private(set) var isValidWithdrawal: Bool
+    let uuid: UUID = UUID()
+    
+    func hash(into hasher: inout Hasher) {
+        hasher.combine(uuid)
+    }
+    
+    static func ==(lhs: AssetsStatus, rhs: AssetsStatus) -> Bool {
+        return lhs.uuid == rhs.uuid
+    }
+}

--- a/BithumbYagomAcamedy/Model/DepositWithdrawalStatusDataManager.swift
+++ b/BithumbYagomAcamedy/Model/DepositWithdrawalStatusDataManager.swift
@@ -1,0 +1,98 @@
+//
+//  DepositWithdrawalStatusDataManager.swift
+//  BithumbYagomAcamedy
+//
+//  Created by Oh Donggeon on 2022/02/28.
+//
+
+import Foundation
+
+final class DepositWithdrawalStatusDataManager {
+    
+    // MARK: - Property
+    private let service: NetworkService
+    private var statuses: [AssetsStatus]
+    
+    init(service: NetworkService = NetworkService()) {
+        self.service = service
+        statuses = []
+    }
+    
+    func requestData(completion: @escaping ([AssetsStatus]) -> Void) {
+        let assetStatusAPI = AssetsStatusAPI()
+        
+        service.request(api: assetStatusAPI) { [weak self] result in
+            guard let self = self else {
+                return
+            }
+            
+            switch result {
+            case .success(let data):
+                self.excuteResultSuccess(data: data, successHandler: completion)
+                
+            case .failure(let error):
+                print(error.localizedDescription)
+            }
+        }
+    }
+    
+    private func excuteResultSuccess(data: Data, successHandler: ([AssetsStatus]) -> Void) {
+        do {
+            let assetStatusValueObject = try self.parseAssetsStatusValueObject(to: data)
+            let result = self.createAssetsStatuses(to: assetStatusValueObject)
+            
+            self.statuses.append(contentsOf: result)
+            successHandler(self.statuses)
+            
+        } catch {
+            print(error.localizedDescription)
+        }
+    }
+    
+    private func parseAssetsStatusValueObject(to data: Data) throws -> AssetsStatusValueObject {
+        do {
+            let parser = JSONParser()
+            let assetsStatuses = try parser.decode(data: data, type: AssetsStatusValueObject.self)
+            
+            return assetsStatuses
+        } catch {
+            print(error.localizedDescription)
+            
+            throw error
+        }
+    }
+    
+    private func createAssetsStatuses(to valueObject: AssetsStatusValueObject) -> [AssetsStatus] {
+        var result: [AssetsStatus] = []
+        
+        for (key, value) in valueObject.assetstatus {
+            result.append(createAssetStatus(key, value))
+        }
+        
+        return result
+    }
+    
+    private func createAssetStatus(_ key: String, _ value: AssetStatusData) -> AssetsStatus {
+        let depositStatus = isValidAssetStatus(to: value.depositStatus)
+        let withdrawalStatus = isValidAssetStatus(to: value.withdrawalStatus)
+        let depositStatusString = assetStatusString(by: depositStatus)
+        let withdrawalStatusString = assetStatusString(by: withdrawalStatus)
+        
+        return AssetsStatus(
+            coinName: key,
+            coinSymbol: key,
+            depositStatus: depositStatusString,
+            withdrawalStatus: withdrawalStatusString,
+            isValidDeposit: depositStatus,
+            isValidWithdrawal: withdrawalStatus
+        )
+    }
+    
+    private func isValidAssetStatus(to status: Int) -> Bool {
+        return status == Int.zero ? false : true
+    }
+    
+    private func assetStatusString(by status: Bool) -> String {
+        return status ? "정상" : "중단"
+    }
+}

--- a/BithumbYagomAcamedy/Model/DepositWithdrawalStatusDataManager.swift
+++ b/BithumbYagomAcamedy/Model/DepositWithdrawalStatusDataManager.swift
@@ -29,7 +29,6 @@ final class DepositWithdrawalStatusDataManager {
             switch result {
             case .success(let data):
                 self.excuteResultSuccess(data: data, successHandler: completion)
-                
             case .failure(let error):
                 print(error.localizedDescription)
             }
@@ -43,7 +42,6 @@ final class DepositWithdrawalStatusDataManager {
             
             self.statuses.append(contentsOf: result)
             successHandler(self.statuses)
-            
         } catch {
             print(error.localizedDescription)
         }

--- a/BithumbYagomAcamedy/View/DepositWithdrawalStatusView/DepositWithdrawalCollectionViewCell.xib
+++ b/BithumbYagomAcamedy/View/DepositWithdrawalStatusView/DepositWithdrawalCollectionViewCell.xib
@@ -13,34 +13,34 @@
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
         <collectionViewCell opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" reuseIdentifier="" id="gTV-IL-0wX" customClass="DepositWithdrawalCollectionViewCell" customModule="BithumbYagomAcamedy" customModuleProvider="target">
-            <rect key="frame" x="0.0" y="0.0" width="597" height="137"/>
+            <rect key="frame" x="0.0" y="0.0" width="466" height="147"/>
             <autoresizingMask key="autoresizingMask"/>
             <view key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center">
-                <rect key="frame" x="0.0" y="0.0" width="597" height="137"/>
+                <rect key="frame" x="0.0" y="0.0" width="466" height="147"/>
                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                 <subviews>
                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="fWK-lh-lLs" userLabel="Coin Name Stack View">
-                        <rect key="frame" x="10" y="48.5" width="86.5" height="50.5"/>
+                        <rect key="frame" x="10" y="60" width="63" height="37.5"/>
                         <subviews>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="비트코인" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="apK-tb-JVr" userLabel="Coin Name Label">
-                                <rect key="frame" x="0.0" y="0.0" width="86.5" height="30"/>
-                                <fontDescription key="fontDescription" style="UICTFontTextStyleTitle1"/>
+                                <rect key="frame" x="0.0" y="0.0" width="63" height="20.5"/>
+                                <fontDescription key="fontDescription" style="UICTFontTextStyleTitle3"/>
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="BTC/KRW" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="kNn-1l-Ioq" userLabel="Coin Symbol And Currency Label">
-                                <rect key="frame" x="0.0" y="30" width="86.5" height="20.5"/>
-                                <fontDescription key="fontDescription" style="UICTFontTextStyleTitle3"/>
+                                <rect key="frame" x="0.0" y="20.5" width="63" height="17"/>
+                                <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                 <color key="textColor" white="0.33333333329999998" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                 <nil key="highlightedColor"/>
                             </label>
                         </subviews>
                     </stackView>
                     <stackView opaque="NO" contentMode="scaleToFill" alignment="center" spacingType="standard" translatesAutoresizingMaskIntoConstraints="NO" id="fjh-Zh-5GP" userLabel="Deposit Status Stack View">
-                        <rect key="frame" x="273" y="63.5" width="51.5" height="20.5"/>
+                        <rect key="frame" x="210" y="70" width="46.5" height="17"/>
                         <subviews>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="NIX-sx-3S3">
-                                <rect key="frame" x="0.0" y="3" width="14" height="14"/>
+                                <rect key="frame" x="0.0" y="1.5" width="14" height="14"/>
                                 <color key="backgroundColor" systemColor="systemBlueColor"/>
                                 <constraints>
                                     <constraint firstAttribute="width" constant="14" id="FC7-yw-HdK"/>
@@ -48,18 +48,18 @@
                                 </constraints>
                             </view>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="입금" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="yCW-i9-WEB">
-                                <rect key="frame" x="22" y="0.0" width="29.5" height="20.5"/>
-                                <fontDescription key="fontDescription" style="UICTFontTextStyleTitle3"/>
+                                <rect key="frame" x="22" y="0.0" width="24.5" height="17"/>
+                                <fontDescription key="fontDescription" style="UICTFontTextStyleHeadline"/>
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
                         </subviews>
                     </stackView>
                     <stackView opaque="NO" contentMode="scaleToFill" alignment="center" spacingType="standard" translatesAutoresizingMaskIntoConstraints="NO" id="W99-bY-w2f" userLabel="Withdrawal Status Stack View">
-                        <rect key="frame" x="535.5" y="63.5" width="51.5" height="20.5"/>
+                        <rect key="frame" x="409.5" y="70" width="46.5" height="17"/>
                         <subviews>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="wQF-Xh-tYQ" userLabel="Status View">
-                                <rect key="frame" x="0.0" y="3" width="14" height="14"/>
+                                <rect key="frame" x="0.0" y="1.5" width="14" height="14"/>
                                 <color key="backgroundColor" systemColor="systemBlueColor"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="14" id="4RW-mV-qDL"/>
@@ -67,8 +67,8 @@
                                 </constraints>
                             </view>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="출금" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="wFK-2q-gN6">
-                                <rect key="frame" x="22" y="0.0" width="29.5" height="20.5"/>
-                                <fontDescription key="fontDescription" style="UICTFontTextStyleTitle3"/>
+                                <rect key="frame" x="22" y="0.0" width="24.5" height="17"/>
+                                <fontDescription key="fontDescription" style="UICTFontTextStyleHeadline"/>
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
@@ -82,17 +82,17 @@
                 <constraint firstItem="W99-bY-w2f" firstAttribute="centerY" secondItem="ZTg-uK-7eu" secondAttribute="centerY" id="2YA-Fe-qxj"/>
                 <constraint firstItem="ZTg-uK-7eu" firstAttribute="trailing" secondItem="W99-bY-w2f" secondAttribute="trailing" constant="10" id="3T3-Hj-MFk"/>
                 <constraint firstItem="fjh-Zh-5GP" firstAttribute="centerX" secondItem="ZTg-uK-7eu" secondAttribute="centerX" id="FSc-YW-oPU"/>
-                <constraint firstItem="W99-bY-w2f" firstAttribute="top" relation="greaterThanOrEqual" secondItem="ZTg-uK-7eu" secondAttribute="top" id="GOw-TF-fvE"/>
+                <constraint firstItem="W99-bY-w2f" firstAttribute="top" relation="greaterThanOrEqual" secondItem="ZTg-uK-7eu" secondAttribute="top" constant="10" id="GOw-TF-fvE"/>
                 <constraint firstItem="fWK-lh-lLs" firstAttribute="leading" secondItem="ZTg-uK-7eu" secondAttribute="leading" constant="10" id="If8-03-YsE"/>
-                <constraint firstItem="ZTg-uK-7eu" firstAttribute="bottom" relation="greaterThanOrEqual" secondItem="fjh-Zh-5GP" secondAttribute="bottom" id="QmW-ft-SGD"/>
-                <constraint firstItem="fjh-Zh-5GP" firstAttribute="top" relation="greaterThanOrEqual" secondItem="ZTg-uK-7eu" secondAttribute="top" id="RRe-nW-pLx"/>
-                <constraint firstItem="ZTg-uK-7eu" firstAttribute="bottom" relation="greaterThanOrEqual" secondItem="W99-bY-w2f" secondAttribute="bottom" id="XkB-S6-G1F"/>
-                <constraint firstItem="ZTg-uK-7eu" firstAttribute="bottom" relation="greaterThanOrEqual" secondItem="fWK-lh-lLs" secondAttribute="bottom" id="gTu-jj-Pgk"/>
+                <constraint firstItem="ZTg-uK-7eu" firstAttribute="bottom" relation="greaterThanOrEqual" secondItem="fjh-Zh-5GP" secondAttribute="bottom" constant="10" id="QmW-ft-SGD"/>
+                <constraint firstItem="fjh-Zh-5GP" firstAttribute="top" relation="greaterThanOrEqual" secondItem="ZTg-uK-7eu" secondAttribute="top" constant="10" id="RRe-nW-pLx"/>
+                <constraint firstItem="ZTg-uK-7eu" firstAttribute="bottom" relation="greaterThanOrEqual" secondItem="W99-bY-w2f" secondAttribute="bottom" constant="10" id="XkB-S6-G1F"/>
+                <constraint firstItem="ZTg-uK-7eu" firstAttribute="bottom" relation="greaterThanOrEqual" secondItem="fWK-lh-lLs" secondAttribute="bottom" constant="10" id="gTu-jj-Pgk"/>
                 <constraint firstItem="fWK-lh-lLs" firstAttribute="centerY" secondItem="ZTg-uK-7eu" secondAttribute="centerY" id="mgh-to-Q8B"/>
                 <constraint firstItem="fjh-Zh-5GP" firstAttribute="centerY" secondItem="ZTg-uK-7eu" secondAttribute="centerY" id="q2M-mE-2Bg"/>
-                <constraint firstItem="fWK-lh-lLs" firstAttribute="top" relation="greaterThanOrEqual" secondItem="ZTg-uK-7eu" secondAttribute="top" id="sGm-ZY-23H"/>
+                <constraint firstItem="fWK-lh-lLs" firstAttribute="top" relation="greaterThanOrEqual" secondItem="ZTg-uK-7eu" secondAttribute="top" constant="10" id="sGm-ZY-23H"/>
             </constraints>
-            <size key="customSize" width="597" height="137"/>
+            <size key="customSize" width="466" height="147"/>
             <connections>
                 <outlet property="coinNameLabel" destination="apK-tb-JVr" id="fZ9-Da-anX"/>
                 <outlet property="coinSymbolAndCurrencyLabel" destination="kNn-1l-Ioq" id="vo1-UK-0sY"/>
@@ -101,7 +101,7 @@
                 <outlet property="withdrawalStatusLabel" destination="wFK-2q-gN6" id="GLc-VE-Zrl"/>
                 <outlet property="withdrawalStatusView" destination="wQF-Xh-tYQ" id="fif-MC-T2f"/>
             </connections>
-            <point key="canvasLocation" x="245.6521739130435" y="40.513392857142854"/>
+            <point key="canvasLocation" x="192.75362318840581" y="53.90625"/>
         </collectionViewCell>
     </objects>
     <resources>

--- a/BithumbYagomAcamedy/View/DepositWithdrawalStatusView/DepositWithdrawalCollectionViewCell.xib
+++ b/BithumbYagomAcamedy/View/DepositWithdrawalStatusView/DepositWithdrawalCollectionViewCell.xib
@@ -47,7 +47,7 @@
                                     <constraint firstAttribute="height" constant="14" id="odw-4Z-gQW"/>
                                 </constraints>
                             </view>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="입금" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="yCW-i9-WEB">
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="입금" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="yCW-i9-WEB">
                                 <rect key="frame" x="22" y="0.0" width="24.5" height="17"/>
                                 <fontDescription key="fontDescription" style="UICTFontTextStyleHeadline"/>
                                 <nil key="textColor"/>
@@ -66,7 +66,7 @@
                                     <constraint firstAttribute="width" constant="14" id="RHM-jj-zKU"/>
                                 </constraints>
                             </view>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="출금" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="wFK-2q-gN6">
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="출금" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="wFK-2q-gN6">
                                 <rect key="frame" x="22" y="0.0" width="24.5" height="17"/>
                                 <fontDescription key="fontDescription" style="UICTFontTextStyleHeadline"/>
                                 <nil key="textColor"/>

--- a/BithumbYagomAcamedy/View/DepositWithdrawalStatusView/DepositWithdrawalCollectionViewCell.xib
+++ b/BithumbYagomAcamedy/View/DepositWithdrawalStatusView/DepositWithdrawalCollectionViewCell.xib
@@ -24,12 +24,14 @@
                         <subviews>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="비트코인" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="apK-tb-JVr" userLabel="Coin Name Label">
                                 <rect key="frame" x="0.0" y="0.0" width="63" height="20.5"/>
+                                <accessibility key="accessibilityConfiguration" label="Coin name"/>
                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle3"/>
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="BTC/KRW" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="kNn-1l-Ioq" userLabel="Coin Symbol And Currency Label">
                                 <rect key="frame" x="0.0" y="20.5" width="63" height="17"/>
+                                <accessibility key="accessibilityConfiguration" label="Coin symbol and currency"/>
                                 <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                 <color key="textColor" white="0.33333333329999998" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                 <nil key="highlightedColor"/>
@@ -49,6 +51,7 @@
                             </view>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="입금" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="yCW-i9-WEB">
                                 <rect key="frame" x="22" y="0.0" width="24.5" height="17"/>
+                                <accessibility key="accessibilityConfiguration" label="Deposit"/>
                                 <fontDescription key="fontDescription" style="UICTFontTextStyleHeadline"/>
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
@@ -68,6 +71,7 @@
                             </view>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="출금" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="wFK-2q-gN6">
                                 <rect key="frame" x="22" y="0.0" width="24.5" height="17"/>
+                                <accessibility key="accessibilityConfiguration" label="Withdrawal"/>
                                 <fontDescription key="fontDescription" style="UICTFontTextStyleHeadline"/>
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>


### PR DESCRIPTION
구현 사항
- Bithumb assets status API를 이용한 입출금 현황 화면 갱신
- 컬렉션 뷰 셀의 높이 조정
- DepositWithdrawalCollectionViewCell.xib 파일에서 Label의 Dynamic type 적용 및 접근성 라벨 추가

문제점
- API에서 코인 이름도 같이 넘어오지 않기 때문에 이후 지역화 할 필요가 있음
<img width="316" alt="Screen Shot 2022-02-28 at 3 37 50 PM" src="https://user-images.githubusercontent.com/18098363/155935953-47b3626f-6f69-4bcd-a06f-c0474a50bc36.png">

