### PR TITLE
CandlestickChart 에서 fetch 해올 때 SortDescriptor를 통해 정렬하도록 수정

### DIFF
--- a/BithumbYagomAcamedy/CandlestickChartScreen/Model/CoinChartCoreDataManager.swift
+++ b/BithumbYagomAcamedy/CandlestickChartScreen/Model/CoinChartCoreDataManager.swift
@@ -24,7 +24,7 @@ struct CoinChartCoreDataManager {
         let request = CandlestickChart.fetchRequest(symbol: symbol, dateFormat: dateFormat)
         let chart = CoreDataManager.shared.fetch(request: request)
         
-        return chart.map { $0.candlestick }.sorted { $0.time < $1.time }
+        return chart.map { $0.candlestick }
     }
     
     func update(

--- a/BithumbYagomAcamedy/CoreData/Entity/CandlestickChart+CoreDataProperties.swift
+++ b/BithumbYagomAcamedy/CoreData/Entity/CandlestickChart+CoreDataProperties.swift
@@ -22,10 +22,12 @@ extension CandlestickChart: Identifiable {
         let request = fetchRequest()
         let symbolPredicate = NSPredicate(format: "symbol == %@", symbol)
         let dateFormatPredicate = NSPredicate(format: "timeInterval == %@", dateFormat.description)
+        let sortDescriptor = NSSortDescriptor(keyPath: \CandlestickChart.time, ascending: true)
         
         request.predicate = NSCompoundPredicate(
             andPredicateWithSubpredicates: [symbolPredicate, dateFormatPredicate]
         )
+        request.sortDescriptors = [sortDescriptor]
         
         return request
     }


### PR DESCRIPTION
구현 사항
이전: Core data를 이용해 Candlestick Model을 불러 온 후 정렬(sorted)하였음
현재: Core data를 이용해 Candlestick Model을 SortDescriptor를 통해 정렬하여 데이터를 가져옴