### PR TITLE
코인 차트 그래프 세그먼트 컨트롤 색상 변경

### DIFF
--- a/BithumbYagomAcamedy/CandlestickChartScreen/View/CoinChart.storyboard
+++ b/BithumbYagomAcamedy/CandlestickChartScreen/View/CoinChart.storyboard
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="19529" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
-    <device id="retina6_1" orientation="portrait" appearance="light"/>
+    <device id="retina6_1" orientation="portrait" appearance="dark"/>
     <dependencies>
         <deployment identifier="iOS"/>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19519"/>
@@ -22,6 +22,7 @@
                                 <subviews>
                                     <segmentedControl opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="top" segmentControlStyle="plain" selectedSegmentIndex="4" translatesAutoresizingMaskIntoConstraints="NO" id="0dB-co-bQR">
                                         <rect key="frame" x="10" y="10" width="239" height="32"/>
+                                        <color key="backgroundColor" systemColor="systemGray6Color"/>
                                         <segments>
                                             <segment title="1분"/>
                                             <segment title="10분"/>
@@ -29,6 +30,7 @@
                                             <segment title="1시간"/>
                                             <segment title="일"/>
                                         </segments>
+                                        <color key="selectedSegmentTintColor" systemColor="systemFillColor"/>
                                         <connections>
                                             <action selector="timeSegmentedControlValueChanged:" destination="Y6W-OH-hqX" eventType="valueChanged" id="uVH-zd-3po"/>
                                         </connections>
@@ -77,6 +79,12 @@
         </systemColor>
         <systemColor name="systemBackgroundColor">
             <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        </systemColor>
+        <systemColor name="systemFillColor">
+            <color red="0.47058823529411764" green="0.47058823529411764" blue="0.50196078431372548" alpha="0.20000000000000001" colorSpace="custom" customColorSpace="sRGB"/>
+        </systemColor>
+        <systemColor name="systemGray6Color">
+            <color red="0.94901960784313721" green="0.94901960784313721" blue="0.96862745098039216" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
         </systemColor>
     </resources>
 </document>


### PR DESCRIPTION
구현 사항
세그먼트 컨트롤 뒷 배경 가려지도록 설정

<img width="271" alt="Screen Shot 2022-03-13 at 3 30 17 PM" src="https://user-images.githubusercontent.com/18098363/158048047-3c274c2e-60d5-4a6e-a13d-5ce7c9d6c3f8.png"> <img width="287" alt="Screen Shot 2022-03-13 at 3 30 06 PM" src="https://user-images.githubusercontent.com/18098363/158048041-248f3b3c-fb5c-41d0-befe-c53582dbd332.png">

Closed #113 